### PR TITLE
use cc crate to use msvc instead of using clang-cl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ log = "0.4"
 [build-dependencies]
 bindgen = "0.49"
 pkg-config = "0.3"
+cc = "1.0"


### PR DESCRIPTION
Hi. I am just checking out `tether` - I'm not sure if this is of any interest to you. If not, no worries of course. 

Using the `cc` crate requires less configuration (for me) to build `tether` on Windows.

I was having trouble getting the hello example to build. I installed `llvm` (version 8) and had `clang-cl.exe` on my path but it did not find the winrt stuff for some reason. (Maybe I need to set an include path?) The script-running code in build.rs did not output the error in creating tether.lib (if there was one) - I got an error later saying more or less "could not find tether with -L".

By using `cc` I got a direct error (cc paniced) telling me that it had chosen Visual Studio 2017 but I didn't have UWP installed. (I have Visual Studio 2019 installed with UWP also.)

