### PR TITLE
wip: allow access to localhost on windows

### DIFF
--- a/examples/open_location.rs
+++ b/examples/open_location.rs
@@ -1,0 +1,57 @@
+use std::env;
+use tether::Window;
+static DEFAULT_URL: &str = "http://localhost:3000/";
+
+fn start() {
+
+    let args = env::args().collect::<Vec<_>>();
+    let url = match args.len() {
+        1 => DEFAULT_URL,
+        2 => &args[1],
+        _ => {
+            eprintln!("{} [location (default: {})]", args[0], DEFAULT_URL);
+            std::process::exit(1);
+        }
+    };
+
+    let window = Window::with_handler(Handler(0));
+    window.title("Hello, world!");
+    window.load(format!(
+        r#"
+            <p>
+                Loading {} ...
+            </p>
+            <script>
+                window.location.href = "{}";
+            </script>
+        "#,
+        url, url
+    ));
+}
+
+struct Handler(pub usize);
+
+impl tether::Handler for Handler {
+    fn handle(&mut self, _window: Window, msg: &str) {
+        println!("{}", msg);
+
+        //     self.0 += 1;
+        //     window.eval(format!(
+        //         "
+        //             document.getElementById('click-count').textContent = {};
+        //         ",
+        //         self.0,
+        //     ));
+    }
+}
+
+impl Drop for Handler {
+    fn drop(&mut self) {
+        println!("Goodbye!");
+        tether::exit();
+    }
+}
+
+fn main() {
+    unsafe { tether::start(start) }
+}


### PR DESCRIPTION
This allows access to localhost and 127.0.0.1 on Windows, which is not allowed by the WebView for security reasons.

It works well enough to load a React app from http://localhost:3000/ but it is buggy/incomplete. Everything is synchronous so websockets are unlikely to ever work with this particular implementation (although I think longer lived connections may actually be possible). This kind of mechanism would also allow loading of pages compiled into the binary.

Is it something you'd be interested in?

(I'm just messing around trying to see how much I can get into a single binary, so the external profile settings file is something I would like to avoid, but it is clearly a more robust answer.) 

Feel free to close the pull request(s) whenever. Thanks for sharing `tether`.